### PR TITLE
Extend joystick position test

### DIFF
--- a/train-system/src/test/java/hu/bme/mit/train/system/TrainSystemTest.java
+++ b/train-system/src/test/java/hu/bme/mit/train/system/TrainSystemTest.java
@@ -27,7 +27,7 @@ public class TrainSystemTest {
 	
 	@Test
 	public void OverridingJoystickPosition_IncreasesReferenceSpeed() {
-		sensor.overrideSpeedLimit(10);
+		sensor.overrideSpeedLimit(15);
 
 		Assert.assertEquals(0, controller.getReferenceSpeed());
 		
@@ -38,7 +38,9 @@ public class TrainSystemTest {
 		controller.followSpeed();
 		Assert.assertEquals(10, controller.getReferenceSpeed());
 		controller.followSpeed();
-		Assert.assertEquals(10, controller.getReferenceSpeed());
+		Assert.assertEquals(15, controller.getReferenceSpeed());
+		controller.followSpeed();
+		Assert.assertEquals(15, controller.getReferenceSpeed());
 	}
 
 	@Test


### PR DESCRIPTION
Extending OverridingJoystickPosition_IncreasesReferenceSpeed in TrainSystemTest.java with another speed increment.